### PR TITLE
Decode in utf-8 when loading graph as dot file

### DIFF
--- a/src/rqt_graph/ros_graph.py
+++ b/src/rqt_graph/ros_graph.py
@@ -376,7 +376,7 @@ class RosGraph(Plugin):
 
         try:
             fh = open(file_name, 'rb')
-            dotcode = fh.read()
+            dotcode = fh.read().decode('utf-8')
             fh.close()
         except IOError:
             return


### PR DESCRIPTION
Adds the decoding part, tested on ros2 humble with a graph generated with the previous commit from @alexvaut 